### PR TITLE
Add strengh bonus to halfling special weapon

### DIFF
--- a/app/src/main/java/org/pathfinderfr/app/database/entity/Weapon.java
+++ b/app/src/main/java/org/pathfinderfr/app/database/entity/Weapon.java
@@ -80,6 +80,8 @@ public class Weapon extends DBEntity {
             return strBonus;
         } else if (name.toLowerCase().contains("arc") && strBonus < 0) {
             return strBonus;
+        } else if (name.toLowerCase().contains("halfelin")) {
+            return strBonus;
         } else {
             return 0;
         }


### PR DESCRIPTION
Il manque le bonus de force aux dégâts du Bâton de jet halfelin.